### PR TITLE
[Feat] reset Species 추가 및 어종 데이터 넘기기

### DIFF
--- a/lib/net/model/net_record.dart
+++ b/lib/net/model/net_record.dart
@@ -400,6 +400,11 @@ class NetRecordProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  void resetSpecies() {
+    _species.clear();
+    notifyListeners();
+  }
+
   void setAmount(List<double> amount) {
     _amount = amount;
     notifyListeners();

--- a/lib/net/view/get_net/get_net_add_fish.dart
+++ b/lib/net/view/get_net/get_net_add_fish.dart
@@ -38,7 +38,7 @@ class _GetNetAddFishState extends State<GetNetAddFish> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // 이전 화면에서 전달된 어종만을 사용하도록 초기화
       selectedList = widget.initialSelectedSpecies.toSet();
-      // 선택 목록이 업데이트되면 UI가 반영되도록 상태를 업데이트합니다.
+      // 선택 목록이 업데이트되면 UI가 반영되도록 상태를 업데이트
       setState(() {});
     });
   }
@@ -56,7 +56,8 @@ class _GetNetAddFishState extends State<GetNetAddFish> {
             Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (context) => const NetTabBarView(initialTabIndex: 0)));
+                    builder: (context) =>
+                        const NetTabBarView(initialTabIndex: 0)));
           },
         ),
         centerTitle: true,
@@ -70,7 +71,14 @@ class _GetNetAddFishState extends State<GetNetAddFish> {
         child: ElevatedButton(
           onPressed: selectedList.isNotEmpty
               ? () {
+                  print("👉🏻 selectedList: $selectedList");
+                  setState(() {
+                    speciesList = selectedList.toList();
+                  });
+                  print("👉🏻 speciesList: $speciesList");
                   netRecordProvider.setSpecies(selectedList);
+                  print(
+                      "👉🏻 netRecordProvider.species: ${netRecordProvider.species}");
                   Navigator.pop(context, widget.recordId);
                 }
               : null,

--- a/lib/net/view/get_net/get_net_fish.dart
+++ b/lib/net/view/get_net/get_net_fish.dart
@@ -25,26 +25,35 @@ class _GetNetFishState extends State<GetNetFish> {
 
   @override
   void initState() {
+    final netRecordProvider =
+        Provider.of<NetRecordProvider>(context, listen: false);
     super.initState();
-    // 최초 로딩 시에만 UserInformationProvider에서 species를 가져와서 NetRecordProvider에 설정
+    speciesList = netRecordProvider.species;
+    print("🥨 speciesList : $speciesList");
+    // 프로바이더에 저장하는데 뭔가 페이지 나가면 자꾸 초기화되는 것 같음. 들어오자마자 init에 복제해둬서 그런가?
+    // init에서 복제하는 조건을 수정할 필요가 있음.
+
+    // 최초 로딩 시에 speciesList가 비어있을 경우에만 UserInformationProvider에서 species를 가져와서 설정
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      // isFirstLoad == true일 때만 실행
-      if (isFirstLoad) {
+      // speciesList가 비어있을 경우에만 실행
+      if (speciesList.isEmpty) {
         final userInformationProvider =
             Provider.of<UserInformationProvider>(context, listen: false);
-        final netRecordProvider =
-            Provider.of<NetRecordProvider>(context, listen: false);
+        // final netRecordProvider =
+        //     Provider.of<NetRecordProvider>(context, listen: false);
 
-        // 초기 데이터 복사
+        // UserInformationProvider에서 species 가져오기
         speciesList = userInformationProvider.species.toSet();
 
         // NetRecordProvider에 species 초기값 설정
         netRecordProvider.setSpecies(speciesList);
-        isFirstLoad = false;
       }
       setState(() {
-        speciesList = speciesList;
+        // speciesList를 UI에 반영
+        // speciesList = NetRecordProvider().species;
+        print("init ---> speciesList: $speciesList");
       });
+      print("222-> speciesList is now: ${speciesList.isEmpty}");
     });
   }
 

--- a/lib/net/view/get_net/get_net_note.dart
+++ b/lib/net/view/get_net/get_net_note.dart
@@ -29,6 +29,7 @@ class _GetNetNoteState extends State<GetNetNote> {
 
   @override
   Widget build(BuildContext context) {
+    final netRecordProvider = Provider.of<NetRecordProvider>(context);
     return Scaffold(
       resizeToAvoidBottomInset: true,
       bottomNavigationBar: Padding(
@@ -38,8 +39,16 @@ class _GetNetNoteState extends State<GetNetNote> {
             // 메모가 비어있지 않으면 저장하고 다음 페이지로 이동
             if (memo.isNotEmpty) {
               _submitMemo();
+              // 넘어가기 전에 어종 초기화
+              netRecordProvider.resetSpecies();
+              print(
+                  "🥨🥨 speciesList after submit (not empty): ${netRecordProvider.species}");
             } else {
               _submitMemo();
+              // 넘어가기 전에 어종 초기화
+              netRecordProvider.resetSpecies();
+              print(
+                  "🥨🥨 speciesList after submit (empty): ${netRecordProvider.species}");
             }
           },
           style: ElevatedButton.styleFrom(

--- a/lib/net/view/throw_net/before_get_net_page.dart
+++ b/lib/net/view/throw_net/before_get_net_page.dart
@@ -38,8 +38,7 @@ class _BeforeGetNetPageState extends State<BeforeGetNetPage> {
       // NetRecordProvider를 통해 상태 업데이트
       Provider.of<NetRecordProvider>(context, listen: false) // listen: false 추가
           .addNewRecord(name, location, throwTime, false,
-              userId: loginModelProvider.kakaoId, wave:wave
-      );
+              userId: loginModelProvider.kakaoId, wave: wave);
     }
   }
 


### PR DESCRIPTION
# ✅ 관련 issue
close #

<br>

# 🗣 설명
<img width="259" alt="스크린샷 2024-10-06 오후 2 50 03" src="https://github.com/user-attachments/assets/b2c87c54-1c04-459b-90c4-1f2e679a2fd7">
<img width="281" alt="스크린샷 2024-10-06 오후 2 50 11" src="https://github.com/user-attachments/assets/9632a7a6-0e5b-4101-a577-827d19605ab9">
<img width="281" alt="스크린샷 2024-10-06 오후 2 50 16" src="https://github.com/user-attachments/assets/708edd84-8f4c-41ba-bc13-c783d749fd81">


<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 어종 무게 입력 후 이전 페이지로 가면 그전에 추가한 어종 남아있도록

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
