### PR TITLE
[Feat] memo 페이지 텍스트 스타일 수정

### DIFF
--- a/lib/net/view/get_net/get_net_note.dart
+++ b/lib/net/view/get_net/get_net_note.dart
@@ -78,6 +78,7 @@ class _GetNetNoteState extends State<GetNetNote> {
               SizedBox(
                 height: 418,
                 child: TextField(
+                  style: header3R(gray6),
                   onChanged: (value) {
                     setState(() {
                       memo = value;
@@ -86,14 +87,14 @@ class _GetNetNoteState extends State<GetNetNote> {
                   maxLines: 35,
                   decoration: InputDecoration(
                     hintText: '이곳에 메모를 입력해주세요.\n메모는 스킵 가능합니다.',
-                    hintStyle: body1(gray6),
+                    hintStyle: header3R(gray2),
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8),
                       borderSide: const BorderSide(color: gray2),
                     ),
                     focusedBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8),
-                      borderSide: const BorderSide(color: primaryBlue500),
+                      borderSide: const BorderSide(color: gray6),
                     ),
                   ),
                 ),

--- a/lib/net/view/get_net/get_net_note.dart
+++ b/lib/net/view/get_net/get_net_note.dart
@@ -88,7 +88,7 @@ class _GetNetNoteState extends State<GetNetNote> {
                   decoration: InputDecoration(
                     hintText: '이곳에 메모를 입력해주세요.\n메모는 스킵 가능합니다.',
                     hintStyle: header3R(gray2),
-                    border: OutlineInputBorder(
+                    enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8),
                       borderSide: const BorderSide(color: gray2),
                     ),


### PR DESCRIPTION
# ✅ 관련 issue
close #

<br>

# 🗣 설명
### 포커스 안되어 있는 경우
<img width="259" alt="스크린샷 2024-10-07 오후 8 23 31" src="https://github.com/user-attachments/assets/ad8c1685-9aad-41d8-b800-ecfa7adf366c">

### 포커스 된 경우
<img width="281" alt="스크린샷 2024-10-07 오후 8 23 55" src="https://github.com/user-attachments/assets/43a42549-9a88-42bd-8f78-f058eeb521bc">

### 텍스트 입력하는 경우
<img width="281" alt="스크린샷 2024-10-07 오후 8 24 12" src="https://github.com/user-attachments/assets/e7fdc61a-378f-472c-9c2f-0908cb9b8c36">


<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 메모 페이지 UI 반영

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
